### PR TITLE
Silence APScheduler logs

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -53,6 +53,7 @@ async def run_telegram_clients():
 
 def main():
     logging.basicConfig(level=logging.INFO, format='%(message)s')
+    logging.getLogger("apscheduler").setLevel(logging.WARNING)
     logging.info('start application')
 
     # Запускаем Flask в отдельном потоке


### PR DESCRIPTION
## Summary
- reduce noise by ignoring APScheduler info logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684399a4a8fc8325911b5723114ae9d8