### PR TITLE
Remove Flask access logs

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,9 @@ def health():
 
 
 def run_flask():
-    app.run(host='0.0.0.0', port=80)
+    # Disable default werkzeug request logging
+    logging.getLogger("werkzeug").setLevel(logging.WARNING)
+    app.run(host='0.0.0.0', port=80, use_reloader=False)
 
 
 async def run_telegram_clients():


### PR DESCRIPTION
## Summary
- disable werkzeug request logs in `run_flask`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68439cbaf5b8832581633e58d5a4a0c7