### PR TITLE
Refactor ClickHouse client creation

### DIFF
--- a/src/admin_logs.py
+++ b/src/admin_logs.py
@@ -1,15 +1,13 @@
 import json
 import logging
 
-import clickhouse_connect
 from telethon.tl.functions.channels import GetAdminLogRequest
 
 from config import config
 from username_utils import extract_usernames
+from clickhouse_utils import get_clickhouse_client
 
-clickhouse = clickhouse_connect.get_client(host=config.db_host, database=config.db_database, port=8123,
-                                           username=config.db_user, password=config.db_password,
-                                           settings={'async_insert': '1', 'wait_for_async_insert': '0'})
+clickhouse = get_clickhouse_client()
 
 
 def get_last_id_from_clickhouse(chat_id):

--- a/src/clickhouse_utils.py
+++ b/src/clickhouse_utils.py
@@ -1,0 +1,19 @@
+import clickhouse_connect
+
+from config import config
+
+_clickhouse_client = None
+
+
+def get_clickhouse_client():
+    global _clickhouse_client
+    if _clickhouse_client is None:
+        _clickhouse_client = clickhouse_connect.get_client(
+            host=config.db_host,
+            database=config.db_database,
+            port=8123,
+            username=config.db_user,
+            password=config.db_password,
+            settings={'async_insert': '1', 'wait_for_async_insert': '0'}
+        )
+    return _clickhouse_client

--- a/src/fetch_sessions.py
+++ b/src/fetch_sessions.py
@@ -1,19 +1,12 @@
 import logging
 from datetime import datetime
 
-import clickhouse_connect
 from telethon.tl.functions.account import GetAuthorizationsRequest
 
 from config import config
+from clickhouse_utils import get_clickhouse_client
 
-clickhouse = clickhouse_connect.get_client(
-    host=config.db_host,
-    database=config.db_database,
-    port=8123,
-    username=config.db_user,
-    password=config.db_password,
-    settings={'async_insert': '1', 'wait_for_async_insert': '0'}
-)
+clickhouse = get_clickhouse_client()
 
 
 async def fetch_user_sessions(client):

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -2,11 +2,10 @@ import json
 import logging
 from datetime import datetime
 
-import clickhouse_connect
-
 from admin_utils import get_admins
 from config import config
 from username_utils import extract_usernames
+from clickhouse_utils import get_clickhouse_client
 
 
 def remove_empty_and_none(obj):
@@ -24,9 +23,7 @@ def remove_empty_and_none(obj):
         return obj
 
 
-clickhouse = clickhouse_connect.get_client(host=config.db_host, database=config.db_database, port=8123,
-                                           username=config.db_user, password=config.db_password,
-                                           settings={'async_insert': '1', 'wait_for_async_insert': '0'})
+clickhouse = get_clickhouse_client()
 
 
 async def save_outgoing(event):


### PR DESCRIPTION
## Summary
- centralize ClickHouse client instance
- use the shared client in `fetch_sessions`, `admin_logs` and `scrapper`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68439e0e224c8325b9e2ecf127d03297