### PR TITLE
Fix outgoing log prefix

### DIFF
--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -37,7 +37,7 @@ async def save_outgoing(event):
     message_dict = remove_empty_and_none(event.message.to_dict())
     message_json = json.dumps(message_dict, default=str, ensure_ascii=False)
     logging.info(
-        "outcoming %12d %-25s %s reply to %s",
+        "outgoing %12d %-25s %s reply to %s",
         event.message.id,
         chat_title[:20],
         event.raw_text,


### PR DESCRIPTION
## Summary
- fix misalignment in outgoing log messages

## Testing
- `python3 -m py_compile src/*.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443ca1645c832585af3084d83137f3