### PR TITLE
Add admin action log details

### DIFF
--- a/src/admin_logs.py
+++ b/src/admin_logs.py
@@ -107,3 +107,12 @@ async def fetch_channel_actions(client, chat_id):
             len(all_data),
             new_last_id,
         )
+        for entry in all_data:
+            logging.info(
+                "admin    %12d %-25s %-20s %-20s %s",
+                entry[0],
+                entry[8][:25],
+                entry[2],
+                entry[9][:20],
+                entry[5],
+            )


### PR DESCRIPTION
## Summary
- show chat title, action type, user, and data for each saved admin action

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_684e5fc76058832586afeef09bf2fe03