### PR TITLE
Fix per-session log prefix

### DIFF
--- a/src/fetch_sessions.py
+++ b/src/fetch_sessions.py
@@ -34,6 +34,14 @@ async def fetch_user_sessions(client):
                 now,
             ]
         )
+        logging.info(
+            "session  %12d %-25s %-10s %-15s %s",
+            session.hash,
+            (session.device_model or "")[:25],
+            (session.platform or "")[:10],
+            session.ip or "",
+            session.app_version or "",
+        )
 
     if all_data:
         clickhouse.insert(


### PR DESCRIPTION
## Summary
- adjust `session` log prefix to match other action log alignment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e76c6deac832596d0343a3f28d058