### PR TITLE
Avoid JSON output for join/leave admin events

### DIFF
--- a/src/admin_logs.py
+++ b/src/admin_logs.py
@@ -14,7 +14,9 @@ clickhouse = get_clickhouse_client()
 def format_log_output(action_type, action, default_message):
     """Return text for admin log output.
 
-    For EditMessage actions return unified diff of message text, otherwise
+    For EditMessage actions return unified diff of message text.
+    For ParticipantJoin/ParticipantLeave actions return an empty string,
+    since their action JSON contains no useful data. For other actions
     return provided default JSON message.
     """
     if action_type == "EditMessage":
@@ -48,6 +50,8 @@ def format_log_output(action_type, action, default_message):
                 )
             except Exception:
                 pass
+    elif action_type in ("ParticipantJoin", "ParticipantLeave"):
+        return ""
     return default_message
 
 


### PR DESCRIPTION
## Summary
- silence useless JSON output for ParticipantJoin/ParticipantLeave admin log events
- keep database entries unchanged

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68500d3c8d28832586e0ba57c369e8bc