### PR TITLE
Add batching for save_incoming

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,12 @@ from flask import Flask, jsonify
 from telethon import events
 
 from config import config
-from scrapper import save_outgoing, save_incoming, save_deleted
+from scrapper import (
+    save_outgoing,
+    save_incoming,
+    save_deleted,
+    flush_incoming_batch,
+)
 from telethon import TelegramClient
 from admin_logs import fetch_channel_actions
 from fetch_sessions import fetch_user_sessions
@@ -47,6 +52,7 @@ async def run_telegram_clients():
         )
 
     scheduler.add_job(fetch_user_sessions, "interval", minutes=1, args=[client])
+    scheduler.add_job(flush_incoming_batch, "interval", seconds=1)
     scheduler.start()
 
     await client.start(phone=config.telephone)


### PR DESCRIPTION
## Summary
- batch incoming messages instead of inserting one-by-one
- schedule periodic flush of the incoming message batch

## Testing
- `pytest -q`
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6868e3b46c80832588a959d2193c02e5