### PR TITLE
Fix clickhouse client concurrency

### DIFF
--- a/src/admin_logs.py
+++ b/src/admin_logs.py
@@ -8,8 +8,6 @@ from username_utils import extract_usernames
 from clickhouse_utils import get_clickhouse_client
 from utils import remove_empty_and_none
 
-clickhouse = get_clickhouse_client()
-
 
 def format_log_output(action_type, action, default_message):
     if action_type == "EditMessage":
@@ -49,6 +47,7 @@ def format_log_output(action_type, action, default_message):
 
 
 def get_last_id_from_clickhouse(chat_id):
+    clickhouse = get_clickhouse_client()
     result = clickhouse.query(
         """
         SELECT max(event_id) AS last_id
@@ -132,6 +131,7 @@ async def fetch_channel_actions(client, chat_id):
             max_id = max(e.id for e in events.events)
 
     if all_data:
+        clickhouse = get_clickhouse_client()
         clickhouse.insert(
             "telegram_user_bot.admin_actions2",
             all_data,

--- a/src/clickhouse_utils.py
+++ b/src/clickhouse_utils.py
@@ -1,14 +1,18 @@
+import contextvars
 import clickhouse_connect
 
 from config import config
 
-_clickhouse_client = None
+
+# Store a client instance per async context to avoid concurrent queries within
+# the same session.  Each task will lazily create its own client on demand.
+_client_var: contextvars.ContextVar = contextvars.ContextVar("clickhouse_client", default=None)
 
 
 def get_clickhouse_client():
-    global _clickhouse_client
-    if _clickhouse_client is None:
-        _clickhouse_client = clickhouse_connect.get_client(
+    client = _client_var.get()
+    if client is None:
+        client = clickhouse_connect.get_client(
             host=config.db_host,
             database=config.db_database,
             port=8123,
@@ -16,4 +20,5 @@ def get_clickhouse_client():
             password=config.db_password,
             settings={"async_insert": "1", "wait_for_async_insert": "0"},
         )
-    return _clickhouse_client
+        _client_var.set(client)
+    return client

--- a/src/fetch_sessions.py
+++ b/src/fetch_sessions.py
@@ -5,10 +5,9 @@ from telethon.tl.functions.account import GetAuthorizationsRequest
 
 from clickhouse_utils import get_clickhouse_client
 
-clickhouse = get_clickhouse_client()
-
 
 async def fetch_user_sessions(client):
+    clickhouse = get_clickhouse_client()
     result = await client(GetAuthorizationsRequest())
     now = datetime.utcnow()
 

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -8,14 +8,13 @@ from username_utils import extract_usernames
 from clickhouse_utils import get_clickhouse_client
 from utils import remove_empty_and_none
 
-clickhouse = get_clickhouse_client()
-
 # Batch for incoming messages
 INCOMING_BATCH_SIZE = 1000
 incoming_batch: List[List] = []
 
 
 async def save_outgoing(event):
+    clickhouse = get_clickhouse_client()
     chat_title = ""
 
     if hasattr(event.chat, "title"):
@@ -79,6 +78,7 @@ async def save_outgoing(event):
 
 
 def save_inc(data):
+    clickhouse = get_clickhouse_client()
     clickhouse.insert(
         "telegram_user_bot.chats_log",
         data,
@@ -99,6 +99,7 @@ def save_inc(data):
 
 
 def save_del(data):
+    clickhouse = get_clickhouse_client()
     clickhouse.insert(
         "telegram_user_bot.deleted_log", data, ["date_time", "chat_id", "message_id"]
     )
@@ -163,6 +164,7 @@ async def save_deleted(event):
     if event.chat_id is None:
         return
 
+    clickhouse = get_clickhouse_client()
     for msg_id in event.deleted_ids:
         save_del([[datetime.now(), event.chat_id, msg_id]])
 


### PR DESCRIPTION
## Summary
- avoid sharing clickhouse client across async tasks by storing one client per async context
- use `get_clickhouse_client` inside `fetch_channel_actions`, `fetch_user_sessions` and scrapper helpers

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868fd51931483259b5f7ae394d8385b