### PR TITLE
Add second client for incoming message logs

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,9 @@ class Config:
         self.api_id = int(os.getenv("API_ID"))
         self.api_hash = os.getenv("API_HASH")
         self.telephone = os.getenv("TELEPHONE")
+        # Optional second telephone number for an additional account that uses
+        # the same API credentials as the primary account.
+        self.telephone_second = os.getenv("TELEPHONE_SECOND")
         self.db_user = os.getenv("CLICKHOUSE_USER")
         self.db_password = os.getenv("CLICKHOUSE_PASSWORD")
         self.db_host = os.getenv("CLICKHOUSE_HOST")

--- a/src/main.py
+++ b/src/main.py
@@ -34,30 +34,51 @@ def run_flask():
 
 
 async def run_telegram_clients():
-    client = TelegramClient("session/alex", config.api_id, config.api_hash)
+    main_client = TelegramClient("session/alex", config.api_id, config.api_hash)
+    second_client = None
 
-    client.add_event_handler(save_outgoing, events.NewMessage(outgoing=True))
-    client.add_event_handler(save_deleted, events.MessageDeleted())
-    client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
-    client.add_event_handler(handle_catbot_trigger, events.NewMessage())
+    # Use the same application credentials for the optional second account.
+    if config.telephone_second:
+        second_client = TelegramClient(
+            "session/alex2",
+            config.api_id,
+            config.api_hash,
+        )
+
+    # Handlers for the primary client
+    main_client.add_event_handler(save_outgoing, events.NewMessage(outgoing=True))
+    main_client.add_event_handler(save_deleted, events.MessageDeleted())
+    # Incoming messages are handled either by the secondary client or the
+    # primary one when no secondary client is configured.
+    if second_client:
+        second_client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
+    else:
+        main_client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
+
+    main_client.add_event_handler(handle_catbot_trigger, events.NewMessage())
 
     scheduler = AsyncIOScheduler()
 
-    chat_ids = [
-        int(cid.strip()) for cid in config.chat_ids if cid.strip().isdigit()
-    ]
+    chat_ids = [int(cid.strip()) for cid in config.chat_ids if cid.strip().isdigit()]
     for chat_id in chat_ids:
         scheduler.add_job(
-            fetch_channel_actions, "interval", minutes=1, args=[client, chat_id]
+            fetch_channel_actions, "interval", minutes=1, args=[main_client, chat_id]
         )
-
-    scheduler.add_job(fetch_user_sessions, "interval", minutes=1, args=[client])
+    scheduler.add_job(fetch_user_sessions, "interval", minutes=1, args=[main_client])
     scheduler.add_job(flush_incoming_batch, "interval", seconds=10)
     scheduler.start()
 
-    await client.start(phone=config.telephone)
+    await main_client.start(phone=config.telephone)
+    if second_client:
+        await second_client.start(phone=config.telephone_second)
 
-    await client.run_until_disconnected()
+    if second_client:
+        await asyncio.gather(
+            main_client.run_until_disconnected(),
+            second_client.run_until_disconnected(),
+        )
+    else:
+        await main_client.run_until_disconnected()
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -45,15 +45,16 @@ async def run_telegram_clients():
             config.api_hash,
         )
 
+    await main_client.get_me()
+    if second_client:
+        await  second_client.get_me();
+
     # Handlers for the primary client
     main_client.add_event_handler(save_outgoing, events.NewMessage(outgoing=True))
     main_client.add_event_handler(save_deleted, events.MessageDeleted())
-    # Incoming messages are handled either by the secondary client or the
-    # primary one when no secondary client is configured.
+    main_client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
     if second_client:
         second_client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
-    else:
-        main_client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
 
     main_client.add_event_handler(handle_catbot_trigger, events.NewMessage())
 

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -57,8 +57,7 @@ async def save_outgoing(event):
             event.chat_id,
             admins,
             event.message.id,
-            event.message.reply_to_msg_id or 0,
-            event.sender_id or 0,
+            event.message.reply_to_msg_id or 0
         ]
     ]
     clickhouse.insert(
@@ -73,8 +72,7 @@ async def save_outgoing(event):
             "id",
             "admins2",
             "message_id",
-            "reply_to",
-            "user_id",
+            "reply_to"
         ],
     )
 
@@ -156,6 +154,7 @@ async def save_incoming(event):
             event.message.id,
             message_content,
             event.message.reply_to_msg_id,
+            event.client.session.session_user_id
         ]
     )
     if len(incoming_batch) >= INCOMING_BATCH_SIZE:

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -58,6 +58,7 @@ async def save_outgoing(event):
             admins,
             event.message.id,
             event.message.reply_to_msg_id or 0,
+            event.sender_id or 0,
         ]
     ]
     clickhouse.insert(
@@ -73,6 +74,7 @@ async def save_outgoing(event):
             "admins2",
             "message_id",
             "reply_to",
+            "user_id",
         ],
     )
 


### PR DESCRIPTION
## Summary
- configure optional telephone for a secondary Telegram account using the same credentials
- run secondary client for `save_incoming` when phone provided
- ensure outgoing messages track `user_id`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6869007be2d08325a698fc8913d11dcb