### PR TITLE
Fix Telethon session attribute error

### DIFF
--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -154,7 +154,7 @@ async def save_incoming(event):
             event.message.id,
             message_content,
             event.message.reply_to_msg_id,
-            event.client.session.session_user_id
+            event.client._self_id
         ]
     )
     if len(incoming_batch) >= INCOMING_BATCH_SIZE:


### PR DESCRIPTION
## Summary
- fix saving incoming events by using `_self_id` instead of nonexistent `session_user_id`

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68690771e81c83258b55bb5f8b114441