### PR TITLE
Add client_id support for outgoing messages

### DIFF
--- a/src/clickhouse_utils.py
+++ b/src/clickhouse_utils.py
@@ -5,8 +5,11 @@ from config import config
 
 
 # Store a client instance per async context to avoid concurrent queries within
-# the same session.  Each task will lazily create its own client on demand.
-_client_var: contextvars.ContextVar = contextvars.ContextVar("clickhouse_client", default=None)
+# the same session. Each task will lazily create its own client on demand.
+_client_var: contextvars.ContextVar = contextvars.ContextVar(
+    "clickhouse_client",
+    default=None,
+)
 
 
 def get_clickhouse_client():

--- a/src/main.py
+++ b/src/main.py
@@ -35,14 +35,19 @@ def run_flask():
 
 async def run_telegram_clients():
     main_client = TelegramClient("session/alex", config.api_id, config.api_hash)
-    second_client = second_client = TelegramClient("session/alex2", config.api_id, config.api_hash,)
+    second_client = TelegramClient(
+        "session/alex2",
+        config.api_id,
+        config.api_hash,
+    )
 
     # Handlers for the primary client
     main_client.add_event_handler(save_outgoing, events.NewMessage(outgoing=True))
     main_client.add_event_handler(save_deleted, events.MessageDeleted())
     main_client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
+    second_client.add_event_handler(save_outgoing, events.NewMessage(outgoing=True))
     second_client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
-    
+
     main_client.add_event_handler(handle_catbot_trigger, events.NewMessage())
 
     scheduler = AsyncIOScheduler()

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -57,7 +57,8 @@ async def save_outgoing(event):
             event.chat_id,
             admins,
             event.message.id,
-            event.message.reply_to_msg_id or 0
+            event.message.reply_to_msg_id or 0,
+            event.client._self_id
         ]
     ]
     clickhouse.insert(
@@ -72,7 +73,8 @@ async def save_outgoing(event):
             "id",
             "admins2",
             "message_id",
-            "reply_to"
+            "reply_to",
+            "client_id"
         ],
     )
 


### PR DESCRIPTION
## Summary
- store the sending client's ID with each outgoing message
- support outbound message logging from the second client
- tidy long lines in clickhouse helper

## Testing
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884ba280844832591c95d64ef58946a