### PR TITLE
Add second client to session fetch scheduler

### DIFF
--- a/src/fetch_sessions.py
+++ b/src/fetch_sessions.py
@@ -31,6 +31,7 @@ async def fetch_user_sessions(client):
                 session.date_created,
                 session.date_active,
                 now,
+                client._self_id,
             ]
         )
 
@@ -51,6 +52,7 @@ async def fetch_user_sessions(client):
                 "date_created",
                 "date_active",
                 "updated_at",
+                "client_id",
             ],
         )
         logging.info(f"Inserted {len(all_data)} session entries.")

--- a/src/main.py
+++ b/src/main.py
@@ -64,6 +64,7 @@ async def run_telegram_clients():
             fetch_channel_actions, "interval", minutes=1, args=[main_client, chat_id]
         )
     scheduler.add_job(fetch_user_sessions, "interval", minutes=1, args=[main_client])
+    scheduler.add_job(fetch_user_sessions, "interval", minutes=1, args=[second_client])
     scheduler.add_job(flush_incoming_batch, "interval", seconds=10)
     scheduler.add_job(
         reset_unread_counters,


### PR DESCRIPTION
## Summary
- schedule fetching user sessions for the secondary Telegram client
- persist `client_id` when storing session info

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_688ac790aed08325b4c6536e255f63e3