### PR TITLE
Add deleted message handler for second client

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -53,6 +53,7 @@ async def run_telegram_clients():
     main_client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
     second_client.add_event_handler(save_outgoing, events.NewMessage(outgoing=True))
     second_client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
+    second_client.add_event_handler(save_deleted, events.MessageDeleted())
 
     main_client.add_event_handler(handle_catbot_trigger, events.NewMessage())
 

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -104,7 +104,9 @@ def save_inc(data):
 def save_del(data):
     clickhouse = get_clickhouse_client()
     clickhouse.insert(
-        "telegram_user_bot.deleted_log", data, ["date_time", "chat_id", "message_id"]
+        "telegram_user_bot.deleted_log",
+        data,
+        ["date_time", "chat_id", "message_id", "client_id"],
     )
 
 
@@ -170,7 +172,7 @@ async def save_deleted(event):
 
     clickhouse = get_clickhouse_client()
     for msg_id in event.deleted_ids:
-        save_del([[datetime.now(), event.chat_id, msg_id]])
+        save_del([[datetime.now(), event.chat_id, msg_id, event.client._self_id]])
 
         try:
             chat_title = clickhouse.query(


### PR DESCRIPTION
## Summary
- register `save_deleted` handler on the secondary Telegram client
- store `client_id` for deleted messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688ad081e6248325a0e3dea50a84cbc8