### PR TITLE
Refactor admin log module

### DIFF
--- a/src/admin_logs.py
+++ b/src/admin_logs.py
@@ -1,6 +1,8 @@
 import json
 import logging
+from dataclasses import dataclass
 from difflib import unified_diff
+from typing import Any, Dict, Iterable, List, Tuple
 
 from telethon.tl.functions.channels import GetAdminLogRequest
 
@@ -9,7 +11,24 @@ from clickhouse_utils import get_clickhouse_client
 from utils import remove_empty_and_none
 
 
-def format_log_output(action_type, action, default_message):
+@dataclass
+class AdminLogRecord:
+    """Container for a single admin log event."""
+
+    event_id: int
+    chat_id: int
+    action_type: str
+    user_id: int
+    date: Any
+    message: str
+    usernames: List[str]
+    chat_usernames: List[str]
+    chat_title: str
+    user_title: str
+
+
+def format_log_output(action_type: str, action: Any, default_message: str) -> str:
+    """Return a human friendly log message for an admin action."""
     if action_type == "EditMessage":
         prev = getattr(action, "prev_message", None)
         new = getattr(action, "new_message", None)
@@ -46,7 +65,8 @@ def format_log_output(action_type, action, default_message):
     return default_message
 
 
-def get_last_id_from_clickhouse(chat_id):
+def get_last_id_from_clickhouse(chat_id: int) -> int:
+    """Return the last processed event_id for the given chat."""
     clickhouse = get_clickhouse_client()
     result = clickhouse.query(
         """
@@ -59,13 +79,27 @@ def get_last_id_from_clickhouse(chat_id):
     return result[0][0] if result and result[0][0] is not None else 0
 
 
-async def fetch_channel_actions(client, chat_id):
+def build_event_maps(events: Any) -> Tuple[Dict[int, List[str]], Dict[int, str], Dict[int, List[str]]]:
+    """Build helper maps for usernames and titles from admin log events."""
+    usernames_map: Dict[int, List[str]] = {}
+    title_map: Dict[int, str] = {}
+
+    for user in events.users:
+        title_map[user.id] = f"{user.first_name or ''} {user.last_name or ''}".strip()
+        usernames_map[user.id] = extract_usernames(user)
+
+    chat_map = {chat.id: extract_usernames(chat) for chat in events.chats}
+    return usernames_map, title_map, chat_map
+
+
+async def fetch_channel_actions(client, chat_id: int) -> None:
+    """Fetch and store channel admin log events since the last processed ID."""
     last_id = get_last_id_from_clickhouse(chat_id)
     channel = await client.get_entity(chat_id)
     chat_usernames = extract_usernames(channel)
     max_id = last_id
     new_last_id = last_id
-    all_data = []
+    all_data: List[List[Any]] = []
 
     while True:
         events = await client(
@@ -77,15 +111,7 @@ async def fetch_channel_actions(client, chat_id):
         if not events.events:
             break
 
-        usernames_map = {}
-        title_map = {}
-        for u in events.users:
-            title_map[u.id] = f"{u.first_name or ''} {u.last_name or ''}".strip()
-            usernames_map[u.id] = extract_usernames(u)
-
-        chat_map = {}
-        for chat in events.chats:
-            chat_map[chat.id] = extract_usernames(chat)
+        usernames_map, title_map, chat_map = build_event_maps(events)
 
         for entry in events.events:
             eid = entry.id
@@ -98,27 +124,41 @@ async def fetch_channel_actions(client, chat_id):
                 default=str,
                 ensure_ascii=False,
             )
+
+            record = AdminLogRecord(
+                event_id=eid,
+                chat_id=chat_id,
+                action_type=action_type,
+                user_id=user_id or 0,
+                date=entry.date,
+                message=message,
+                usernames=usernames_map.get(user_id) or chat_map.get(user_id, []),
+                chat_usernames=chat_usernames,
+                chat_title=channel.title,
+                user_title=title_map.get(user_id, ""),
+            )
             all_data.append(
                 [
-                    eid,
-                    chat_id,
-                    action_type,
-                    user_id or 0,
-                    entry.date,
-                    message,
-                    usernames_map.get(user_id) or chat_map.get(user_id, []),
-                    chat_usernames,
-                    channel.title,
-                    title_map.get(user_id, ""),
+                    record.event_id,
+                    record.chat_id,
+                    record.action_type,
+                    record.user_id,
+                    record.date,
+                    record.message,
+                    record.usernames,
+                    record.chat_usernames,
+                    record.chat_title,
+                    record.user_title,
                 ]
             )
-            log_text = format_log_output(action_type, entry.action, message)
+
+            log_text = format_log_output(record.action_type, entry.action, record.message)
             logging.info(
                 "admin    %12d %-25s %-20s %-20s %s",
-                eid,
+                record.event_id,
                 channel.title[:25],
-                action_type,
-                title_map.get(user_id, "")[:20],
+                record.action_type,
+                record.user_title[:20],
                 log_text,
             )
 


### PR DESCRIPTION
## Summary
- create dataclass for storing admin log records
- extract helper to build username maps
- simplify `fetch_channel_actions` logic
- add type hints and docstrings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c1e0f06d08325a4529983b3379414