### PR TITLE
Remove Nullable columns

### DIFF
--- a/migrations/007_remove_nullable_columns.sql
+++ b/migrations/007_remove_nullable_columns.sql
@@ -1,0 +1,68 @@
+SET allow_suspicious_low_cardinality_types = 1;
+
+ALTER TABLE telegram_user_bot.chats_log
+    MODIFY COLUMN first_name String,
+    MODIFY COLUMN second_name String,
+    MODIFY COLUMN reply_to UInt64;
+
+ALTER TABLE telegram_user_bot.user_sessions
+    MODIFY COLUMN system_version LowCardinality(String),
+    MODIFY COLUMN app_version LowCardinality(String),
+    MODIFY COLUMN ip LowCardinality(String);
+
+DROP VIEW IF EXISTS telegram_user_bot.mv_chat_stat;
+DROP VIEW IF EXISTS telegram_user_bot.mv_user_stat;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS telegram_user_bot.mv_chat_stat
+(
+    `client_id` LowCardinality(UInt64),
+    `chat_id` Int64,
+    `last_title` String,
+    `msg_count` AggregateFunction(count),
+    `reply_msg_count` AggregateFunction(sum, UInt8),
+    `participants` AggregateFunction(groupUniqArray, UInt64),
+    `last_message_id` AggregateFunction(max, Int64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (client_id, chat_id)
+SETTINGS index_granularity = 8192
+AS SELECT
+    client_id,
+    chat_id,
+    anyLast(chat_title) AS last_title,
+    countState() AS msg_count,
+    sumState(if(reply_to != 0, 1, 0)) AS reply_msg_count,
+    groupUniqArrayState(user_id) AS participants,
+    maxState(message_id) AS last_message_id
+FROM telegram_user_bot.chats_log
+GROUP BY
+    client_id,
+    chat_id;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS telegram_user_bot.mv_user_stat
+(
+    `client_id` LowCardinality(UInt64),
+    `user_id` UInt64,
+    `username` Array(String),
+    `first_name` String,
+    `second_name` String,
+    `chats` AggregateFunction(groupUniqArray, Int64),
+    `msg_count` AggregateFunction(count),
+    `reply_msg_count` AggregateFunction(sum, UInt8)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (client_id, user_id)
+SETTINGS index_granularity = 8192
+AS SELECT
+    client_id,
+    user_id,
+    anyLast(username) AS username,
+    anyLast(first_name) AS first_name,
+    anyLast(second_name) AS second_name,
+    groupUniqArrayState(chat_id) AS chats,
+    countState() AS msg_count,
+    sumState(if(reply_to != 0, 1, 0)) AS reply_msg_count
+FROM telegram_user_bot.chats_log
+GROUP BY
+    client_id,
+    user_id;

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -124,11 +124,11 @@ async def save_incoming(event):
     usernames = extract_usernames(event.message.sender)
     chat_usernames = extract_usernames(event.chat)
     try:
-        first_name = event.message.sender.first_name
-        last_name = event.message.sender.last_name
+        first_name = event.message.sender.first_name or ""
+        last_name = event.message.sender.last_name or ""
     except Exception:
-        first_name = None
-        last_name = None
+        first_name = ""
+        last_name = ""
 
     message_content = event.raw_text
     if event.raw_text == "":
@@ -159,7 +159,7 @@ async def save_incoming(event):
             event.message.sender.id,
             event.message.id,
             message_content,
-            event.message.reply_to_msg_id,
+            event.message.reply_to_msg_id or 0,
             event.client._self_id
         ]
     )


### PR DESCRIPTION
## Summary
- remove Nullable columns from Chat and user session tables
- rebuild materialized views without Nullable types
- sanitize incoming messages to avoid NULL writes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f9e30c3d0832587c01cb0dd4d9092