### PR TITLE
Ensure pending messages flush on exit

### DIFF
--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -1,3 +1,4 @@
+import atexit
 import json
 import logging
 from datetime import datetime
@@ -208,3 +209,6 @@ async def save_deleted(event):
             str(chat_title)[:20],
             message,
         )
+
+
+atexit.register(flush_incoming_batch)


### PR DESCRIPTION
## Summary
- Flush incoming message batch when the program terminates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fa5946e2c83259aa38ce3e61235f1