### PR TITLE
Sort ClickHouse columns and add migration

### DIFF
--- a/migrations/001_create_admin_actions2.sql
+++ b/migrations/001_create_admin_actions2.sql
@@ -1,13 +1,13 @@
 CREATE TABLE IF NOT EXISTS admin_actions2 (
-    event_id       UInt64,
-    chat_id        UInt64,
     action_type    LowCardinality(String),
-    user_id        UInt64,
-    date           DateTime,
-    message        String,
-    usernames      Array(String),
-    chat_usernames Array(LowCardinality(String)),
+    chat_id        UInt64,
     chat_title     LowCardinality(String),
-    user_title     String
+    chat_usernames Array(LowCardinality(String)),
+    date           DateTime,
+    event_id       UInt64,
+    message        String,
+    user_id        UInt64,
+    user_title     String,
+    usernames      Array(String)
 ) ENGINE = ReplacingMergeTree
 ORDER BY (chat_id, event_id);

--- a/migrations/002_create_chats_log.sql
+++ b/migrations/002_create_chats_log.sql
@@ -2,17 +2,17 @@ SET allow_suspicious_low_cardinality_types = 1;
 
 
 CREATE TABLE IF NOT EXISTS  chats_log (
-    date_time      DateTime,
-    chat_title     LowCardinality(String),
     chat_id        Int64,
-    username       Array(String),
+    chat_title     LowCardinality(String),
+    chat_usernames Array(LowCardinality(String)),
+    client_id      LowCardinality(UInt64),
+    date_time      DateTime,
     first_name     Nullable(String),
+    message        String,
+    message_id     Int64,
+    reply_to       Nullable(UInt64),
     second_name    Nullable(String),
     user_id        UInt64,
-    message_id     Int64,
-    message        String,
-    chat_usernames Array(LowCardinality(String)),
-    reply_to       Nullable(UInt64),
-    client_id      LowCardinality(UInt64)
+    username       Array(String)
 ) ENGINE = ReplacingMergeTree(date_time)
 ORDER BY (chat_id, message_id);

--- a/migrations/003_create_deleted_log.sql
+++ b/migrations/003_create_deleted_log.sql
@@ -1,9 +1,9 @@
 SET allow_suspicious_low_cardinality_types = 1;
 
 CREATE TABLE IF NOT EXISTS  deleted_log (
-    date_time  DateTime,
     chat_id    Int64,
-    message_id Int64,
-    client_id  LowCardinality(UInt64)
+    client_id  LowCardinality(UInt64),
+    date_time  DateTime,
+    message_id Int64
 ) ENGINE = ReplacingMergeTree(date_time)
 ORDER BY (chat_id, message_id);

--- a/migrations/004_create_telegram_messages_new.sql
+++ b/migrations/004_create_telegram_messages_new.sql
@@ -1,15 +1,15 @@
 SET allow_suspicious_low_cardinality_types = 1;
 
 CREATE TABLE IF NOT EXISTS  telegram_messages_new (
-    date_time  DateTime,
-    message    String,
-    title      LowCardinality(String),
-    id         Int64,
     admins2    Array(LowCardinality(String)),
-    usernames  Array(LowCardinality(String)),
+    client_id  LowCardinality(UInt64),
+    date_time  DateTime,
+    id         Int64,
+    message    String,
     message_id UInt64,
-    reply_to   UInt64,
     raw        String,
-    client_id  LowCardinality(UInt64)
+    reply_to   UInt64,
+    title      LowCardinality(String),
+    usernames  Array(LowCardinality(String))
 ) ENGINE = MergeTree
 ORDER BY date_time;

--- a/migrations/005_create_user_sessions.sql
+++ b/migrations/005_create_user_sessions.sql
@@ -1,18 +1,18 @@
 SET allow_suspicious_low_cardinality_types = 1;
 
 CREATE TABLE IF NOT EXISTS  user_sessions (
-    hash           Int64,
-    device_model   LowCardinality(String),
-    platform       LowCardinality(String),
-    system_version LowCardinality(Nullable(String)),
     app_name       LowCardinality(String),
     app_version    LowCardinality(Nullable(String)),
-    ip             LowCardinality(Nullable(String)),
+    client_id      LowCardinality(UInt64),
     country        LowCardinality(String),
-    region         LowCardinality(String),
-    date_created   DateTime,
     date_active    DateTime,
-    updated_at     DateTime,
-    client_id      LowCardinality(UInt64)
+    date_created   DateTime,
+    device_model   LowCardinality(String),
+    hash           Int64,
+    ip             LowCardinality(Nullable(String)),
+    platform       LowCardinality(String),
+    region         LowCardinality(String),
+    system_version LowCardinality(Nullable(String)),
+    updated_at     DateTime
 ) ENGINE = ReplacingMergeTree(updated_at)
 ORDER BY hash;

--- a/migrations/009_sort_columns.sql
+++ b/migrations/009_sort_columns.sql
@@ -1,0 +1,60 @@
+SET allow_suspicious_low_cardinality_types = 1;
+
+ALTER TABLE telegram_user_bot.admin_actions2
+    MODIFY COLUMN action_type LowCardinality(String) FIRST,
+    MODIFY COLUMN chat_id UInt64 AFTER action_type,
+    MODIFY COLUMN chat_title LowCardinality(String) AFTER chat_id,
+    MODIFY COLUMN chat_usernames Array(LowCardinality(String)) AFTER chat_title,
+    MODIFY COLUMN date DateTime AFTER chat_usernames,
+    MODIFY COLUMN event_id UInt64 AFTER date,
+    MODIFY COLUMN message String AFTER event_id,
+    MODIFY COLUMN user_id UInt64 AFTER message,
+    MODIFY COLUMN user_title String AFTER user_id,
+    MODIFY COLUMN usernames Array(String) AFTER user_title;
+
+ALTER TABLE telegram_user_bot.chats_log
+    MODIFY COLUMN chat_id Int64 FIRST,
+    MODIFY COLUMN chat_title LowCardinality(String) AFTER chat_id,
+    MODIFY COLUMN chat_usernames Array(LowCardinality(String)) AFTER chat_title,
+    MODIFY COLUMN client_id LowCardinality(UInt64) AFTER chat_usernames,
+    MODIFY COLUMN date_time DateTime AFTER client_id,
+    MODIFY COLUMN first_name String AFTER date_time,
+    MODIFY COLUMN message String AFTER first_name,
+    MODIFY COLUMN message_id Int64 AFTER message,
+    MODIFY COLUMN reply_to UInt64 AFTER message_id,
+    MODIFY COLUMN second_name String AFTER reply_to,
+    MODIFY COLUMN user_id UInt64 AFTER second_name,
+    MODIFY COLUMN username Array(String) AFTER user_id;
+
+ALTER TABLE telegram_user_bot.deleted_log
+    MODIFY COLUMN chat_id Int64 FIRST,
+    MODIFY COLUMN client_id LowCardinality(UInt64) AFTER chat_id,
+    MODIFY COLUMN date_time DateTime AFTER client_id,
+    MODIFY COLUMN message_id Int64 AFTER date_time;
+
+ALTER TABLE telegram_user_bot.telegram_messages_new
+    MODIFY COLUMN admins2 Array(LowCardinality(String)) FIRST,
+    MODIFY COLUMN client_id LowCardinality(UInt64) AFTER admins2,
+    MODIFY COLUMN date_time DateTime AFTER client_id,
+    MODIFY COLUMN id Int64 AFTER date_time,
+    MODIFY COLUMN message String AFTER id,
+    MODIFY COLUMN message_id UInt64 AFTER message,
+    MODIFY COLUMN raw String AFTER message_id,
+    MODIFY COLUMN reply_to UInt64 AFTER raw,
+    MODIFY COLUMN title LowCardinality(String) AFTER reply_to,
+    MODIFY COLUMN usernames Array(LowCardinality(String)) AFTER title;
+
+ALTER TABLE telegram_user_bot.user_sessions
+    MODIFY COLUMN app_name LowCardinality(String) FIRST,
+    MODIFY COLUMN app_version LowCardinality(Nullable(String)) AFTER app_name,
+    MODIFY COLUMN client_id LowCardinality(UInt64) AFTER app_version,
+    MODIFY COLUMN country LowCardinality(String) AFTER client_id,
+    MODIFY COLUMN date_active DateTime AFTER country,
+    MODIFY COLUMN date_created DateTime AFTER date_active,
+    MODIFY COLUMN device_model LowCardinality(String) AFTER date_created,
+    MODIFY COLUMN hash Int64 AFTER device_model,
+    MODIFY COLUMN ip LowCardinality(Nullable(String)) AFTER hash,
+    MODIFY COLUMN platform LowCardinality(String) AFTER ip,
+    MODIFY COLUMN region LowCardinality(String) AFTER platform,
+    MODIFY COLUMN system_version LowCardinality(Nullable(String)) AFTER region,
+    MODIFY COLUMN updated_at DateTime AFTER system_version;


### PR DESCRIPTION
## Summary
- reorder columns alphabetically in initial table creation migrations
- add migration to reorder existing tables for consistent column order

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68977860d3fc8325858a373b545f7f03