### PR TITLE
Use ndiff for admin log diffs

### DIFF
--- a/src/admin_logs.py
+++ b/src/admin_logs.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from dataclasses import dataclass
-from difflib import unified_diff
+from difflib import ndiff
 from typing import Any, List
 
 from telethon.tl.functions.channels import GetAdminLogRequest
@@ -33,12 +33,9 @@ def format_log_output(action_type, action, default_message):
         prev_text = getattr(prev, "message", "") if prev else ""
         new_text = getattr(new, "message", "") if new else ""
         diff = "\n".join(
-            unified_diff(
+            ndiff(
                 prev_text.splitlines(),
                 new_text.splitlines(),
-                fromfile="prev",
-                tofile="new",
-                lineterm="",
             )
         )
         return diff


### PR DESCRIPTION
## Summary
- generate edit diffs with `difflib.ndiff` instead of `unified_diff`

## Testing
- `pytest -q`
- `flake8 src/admin_logs.py`


------
https://chatgpt.com/codex/tasks/task_e_689952616cb883258e12dcaff7ec436e