### PR TITLE
Log edited Telegram messages in ClickHouse

### DIFF
--- a/migrations/011_create_edited_log.sql
+++ b/migrations/011_create_edited_log.sql
@@ -1,0 +1,10 @@
+SET allow_suspicious_low_cardinality_types = 1;
+
+CREATE TABLE IF NOT EXISTS  edited_log (
+    date_time  DateTime,
+    chat_id    Int64,
+    message_id Int64,
+    message    String,
+    client_id  LowCardinality(UInt64)
+) ENGINE = ReplacingMergeTree(date_time)
+ORDER BY (chat_id, message_id);

--- a/migrations/011_create_edited_log.sql
+++ b/migrations/011_create_edited_log.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS  edited_log (
     chat_id    Int64,
     message_id Int64,
     message    String,
+    diff       String,
     client_id  LowCardinality(UInt64)
 ) ENGINE = ReplacingMergeTree(date_time)
 ORDER BY (chat_id, message_id);

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ from scrapper import (
     save_outgoing,
     save_incoming,
     save_deleted,
+    save_edited,
     flush_incoming_batch,
 )
 from telethon import TelegramClient
@@ -52,9 +53,11 @@ async def run_telegram_clients():
     main_client.add_event_handler(save_outgoing, events.NewMessage(outgoing=True))
     main_client.add_event_handler(save_deleted, events.MessageDeleted())
     main_client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
+    main_client.add_event_handler(save_edited, events.MessageEdited())
     second_client.add_event_handler(save_outgoing, events.NewMessage(outgoing=True))
     second_client.add_event_handler(save_incoming, events.NewMessage(incoming=True))
     second_client.add_event_handler(save_deleted, events.MessageDeleted())
+    second_client.add_event_handler(save_edited, events.MessageEdited())
 
     main_client.add_event_handler(handle_catbot_trigger, events.NewMessage())
 

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -196,19 +196,7 @@ async def save_edited(event):
             {"chat_id": event.chat_id, "message_id": event.message.id},
         ).result_rows[0][0]
     except Exception:
-        try:
-            original = clickhouse.query(
-                """
-            SELECT message
-            FROM telegram_user_bot.telegram_messages_new
-            WHERE id = {chat_id:Int64} AND message_id = {message_id:Int64}
-            ORDER BY date_time DESC
-            LIMIT 1
-            """,
-                {"chat_id": event.chat_id, "message_id": event.message.id},
-            ).result_rows[0][0]
-        except Exception:
-            original = ""
+        original = ""
 
     diff = "\n".join(
         difflib.ndiff(original.splitlines(), message_content.splitlines())


### PR DESCRIPTION
## Summary
- capture edited Telegram messages and persist them in ClickHouse
- handle `MessageEdited` events for all Telegram clients
- create ClickHouse `edited_log` table

## Testing
- `python -m py_compile src/scrapper.py src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a04d1715e88325915a973171e061a4