### PR TITLE
Show colored diff in edited logs

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -15,6 +15,7 @@ COLOR_MAP = {
     "incoming": "\033[92m",  # green
     "outgoing": "\033[94m",  # blue
     "deleted": "\033[91m",   # red
+    "edited": "\033[93m",    # yellow
 }
 
 
@@ -24,4 +25,16 @@ def colorize(message_type: str, text: str) -> str:
     return f"{color}{text}{reset}"
 
 
-__all__ = ["remove_empty_and_none", "colorize"]
+def colorize_diff(diff: str) -> str:
+    colored_lines = []
+    for line in diff.splitlines():
+        if line.startswith("+"):
+            colored_lines.append(f"\033[92m{line}\033[0m")
+        elif line.startswith("-"):
+            colored_lines.append(f"\033[91m{line}\033[0m")
+        else:
+            colored_lines.append(line)
+    return "\n".join(colored_lines)
+
+
+__all__ = ["remove_empty_and_none", "colorize", "colorize_diff"]


### PR DESCRIPTION
## Summary
- color edited log entries in yellow
- show only diff for edited messages with colorized additions and removals

## Testing
- `flake8 src/scrapper.py src/utils.py`
- `python -m py_compile src/utils.py src/scrapper.py`


------
https://chatgpt.com/codex/tasks/task_e_68a055df915483259c84ed2d72646634