### PR TITLE
Ignore non-text edits

### DIFF
--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -175,12 +175,7 @@ async def save_edited(event):
 
     message_content = event.raw_text
     if not message_content:
-        try:
-            message_dict = remove_empty_and_none(event.message.to_dict())
-            message_content = json.dumps(message_dict, default=str, ensure_ascii=False)
-        except Exception as e:
-            logging.error(f"Error serializing edited message: {e}")
-            message_content = "[Error serializing message]"
+        return
 
     clickhouse = get_clickhouse_client()
 


### PR DESCRIPTION
## Summary
- skip edit logging when the edited message has no text

## Testing
- `flake8 src/scrapper.py && echo "flake8 passed"`


------
https://chatgpt.com/codex/tasks/task_e_68a05bfa546083258ad248e3a224fa9f