### PR TITLE
Store editor and chat IDs in edit log

### DIFF
--- a/migrations/012_add_user_id_to_edited_log.sql
+++ b/migrations/012_add_user_id_to_edited_log.sql
@@ -1,0 +1,1 @@
+ALTER TABLE edited_log ADD COLUMN user_id Int64 AFTER diff;

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -197,6 +197,8 @@ async def save_edited(event):
         difflib.ndiff(original.splitlines(), message_content.splitlines())
     )
 
+    user_id = event.message.sender_id or 0
+
     clickhouse.insert(
         "telegram_user_bot.edited_log",
         [
@@ -206,10 +208,19 @@ async def save_edited(event):
                 event.message.id,
                 message_content,
                 diff,
+                user_id,
                 event.client._self_id,
             ]
         ],
-        ["date_time", "chat_id", "message_id", "message", "diff", "client_id"],
+        [
+            "date_time",
+            "chat_id",
+            "message_id",
+            "message",
+            "diff",
+            "user_id",
+            "client_id",
+        ],
     )
 
     logging.info(


### PR DESCRIPTION
## Summary
- capture the sender's user ID and chat ID when messages are edited and write them to ClickHouse, keeping client ID as the last column
- add migration to include `user_id` column before `client_id` in `edited_log`

## Testing
- `python -m py_compile src/scrapper.py`
- `flake8 src/scrapper.py`


------
https://chatgpt.com/codex/tasks/task_e_68a05cdf25188325bd76e5711b8c9812