### PR TITLE
feat: improve outgoing message color

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -13,7 +13,7 @@ def remove_empty_and_none(obj: Any):
 
 COLOR_MAP = {
     "incoming": "\033[92m",  # green
-    "outgoing": "\033[94m",  # blue
+    "outgoing": "\033[95m",  # magenta for better readability
     "deleted": "\033[91m",   # red
     "edited": "\033[93m",    # yellow
 }


### PR DESCRIPTION
## Summary
- adjust outgoing message color to magenta for better readability

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a09d54ada083258d3c8bad843f7ddc