### PR TITLE
Skip edit log entries for unchanged messages

### DIFF
--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -207,6 +207,9 @@ async def save_edited(event):
     except Exception:
         original = ""
 
+    if original == message_content:
+        return
+
     diff = "\n".join(
         difflib.ndiff(original.splitlines(), message_content.splitlines())
     )


### PR DESCRIPTION
## Summary
- Avoid recording edited logs when the message text hasn't changed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a18956421c83259939e19681c60c04