### PR TITLE
Store original message and compute unified diffs

### DIFF
--- a/migrations/017_add_original_message_to_edited_log.sql
+++ b/migrations/017_add_original_message_to_edited_log.sql
@@ -1,0 +1,41 @@
+SET allow_suspicious_low_cardinality_types = 1;
+
+ALTER TABLE edited_log ADD COLUMN original_message String AFTER message_id;
+
+CREATE OR REPLACE VIEW telegram_user_bot.edit_log_hr AS
+SELECT
+    el.date_time,
+    el.client_id,
+    el.chat_id,
+    cs.chat_title,                -- из mv_chat_stat, схлопнуто
+    el.message_id,
+    el.original_message,
+    el.message,
+    el.diff,
+    el.user_id,
+    us.username,                  -- из mv_user_stat, схлопнуто
+    us.first_name,
+    us.second_name
+FROM telegram_user_bot.edited_log AS el
+         LEFT JOIN
+     (
+         SELECT
+             client_id,
+             chat_id,
+             anyLast(last_title) AS chat_title
+         FROM telegram_user_bot.mv_chat_stat
+         GROUP BY client_id, chat_id
+     ) AS cs USING (client_id, chat_id)
+         LEFT JOIN
+     (
+         SELECT
+             client_id,
+             user_id,
+             anyLast(username)   AS username,
+             anyLast(first_name) AS first_name,
+             anyLast(second_name) AS second_name
+         FROM telegram_user_bot.mv_user_stat
+         GROUP BY client_id, user_id
+     ) AS us
+     ON  us.client_id = el.client_id
+         AND us.user_id   = toUInt64(el.user_id);

--- a/src/admin_logs.py
+++ b/src/admin_logs.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from dataclasses import dataclass
-from difflib import ndiff
+from difflib import unified_diff
 from typing import Any, List
 
 from telethon.tl.functions.channels import GetAdminLogRequest
@@ -32,10 +32,11 @@ def format_log_output(action_type, action, default_message):
         new = getattr(action, "new_message", None)
         prev_text = getattr(prev, "message", "") if prev else ""
         new_text = getattr(new, "message", "") if new else ""
-        diff = "\n\n".join(
-            ndiff(
+        diff = "\n".join(
+            unified_diff(
                 prev_text.splitlines(),
                 new_text.splitlines(),
+                lineterm="",
             )
         )
         return diff

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -125,6 +125,7 @@ def flush_batches():
                 "date_time",
                 "chat_id",
                 "message_id",
+                "original_message",
                 "message",
                 "diff",
                 "user_id",
@@ -211,7 +212,11 @@ async def save_edited(event):
         return
 
     diff = "\n".join(
-        difflib.ndiff(original.splitlines(), message_content.splitlines())
+        difflib.unified_diff(
+            original.splitlines(),
+            message_content.splitlines(),
+            lineterm="",
+        )
     )
 
     user_id = event.message.sender_id or 0
@@ -221,6 +226,7 @@ async def save_edited(event):
             datetime.now(),
             event.chat_id,
             event.message.id,
+            original,
             message_content,
             diff,
             user_id,


### PR DESCRIPTION
## Summary
- save original message before an edit and generate unified diffs
- update admin log diff rendering to unified diff
- migrate edited_log table and view to include original_message

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3e83c4e388325b6178a5e4bc13a1d