### PR TITLE
Add separate API credentials for second Telegram client

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,8 @@ def _get_chat_ids() -> List[str]:
 class Config:
     api_id = int(os.getenv("API_ID"))
     api_hash = os.getenv("API_HASH")
+    api_id_second = int(os.getenv("API_ID_SECOND"))
+    api_hash_second = os.getenv("API_HASH_SECOND")
     telephone = os.getenv("TELEPHONE")
     telephone_second = os.getenv("TELEPHONE_SECOND")
     db_user = os.getenv("CLICKHOUSE_USER")

--- a/src/main.py
+++ b/src/main.py
@@ -20,12 +20,12 @@ from fetch_sessions import fetch_user_sessions
 from auto_catbot import handle_catbot_trigger
 
 
-def create_client(session_name: str) -> TelegramClient:
-    """Create a Telegram client using the global config."""
+def create_client(session_name: str, api_id: int, api_hash: str) -> TelegramClient:
+    """Create a Telegram client using provided API credentials."""
     return TelegramClient(
         session_name,
-        config.api_id,
-        config.api_hash,
+        api_id,
+        api_hash,
         device_model="Telegram Android",
         app_version="10.5.1",
     )
@@ -47,8 +47,10 @@ def run_flask():
 
 
 async def run_telegram_clients():
-    main_client = create_client("session/alex")
-    second_client = create_client("session/alex2")
+    main_client = create_client("session/alex", config.api_id, config.api_hash)
+    second_client = create_client(
+        "session/alex2", config.api_id_second, config.api_hash_second
+    )
 
     main_client.add_event_handler(save_outgoing, events.NewMessage(outgoing=True))
     main_client.add_event_handler(save_deleted, events.MessageDeleted())


### PR DESCRIPTION
## Summary
- support second set of API credentials via `API_ID_SECOND` and `API_HASH_SECOND`
- allow client factory to accept API credentials and use second credentials for second client

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a40757c62c8325a775d31ed95c8f80