### PR TITLE
Skip diff when original message is empty

### DIFF
--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -211,13 +211,16 @@ async def save_edited(event):
     if original == message_content:
         return
 
-    diff = "\n".join(
-        difflib.unified_diff(
-            original.splitlines(),
-            message_content.splitlines(),
-            lineterm="",
+    if original:
+        diff = "\n".join(
+            difflib.unified_diff(
+                original.splitlines(),
+                message_content.splitlines(),
+                lineterm="",
+            )
         )
-    )
+    else:
+        diff = ""
 
     user_id = event.message.sender_id or 0
 


### PR DESCRIPTION
## Summary
- compute diff for edited messages only when original text is available
- restore admin log formatting to its prior behavior

## Testing
- `flake8 src/admin_logs.py src/scrapper.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a40eb2e57483259ecab0e61dba301a