### PR TITLE
Store Telegram sessions in ClickHouse

### DIFF
--- a/migrations/018_create_client_sessions.sql
+++ b/migrations/018_create_client_sessions.sql
@@ -1,0 +1,8 @@
+SET allow_suspicious_low_cardinality_types = 1;
+
+CREATE TABLE IF NOT EXISTS client_sessions (
+    name LowCardinality(String),
+    session String,
+    updated_at DateTime
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY name;

--- a/src/session_storage.py
+++ b/src/session_storage.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import Optional
+
+from clickhouse_utils import get_clickhouse_client
+
+
+def load_session(name: str) -> Optional[str]:
+    """Retrieve the stored session string for a given client name."""
+    client = get_clickhouse_client()
+    result = client.query(
+        """
+        SELECT session
+        FROM telegram_user_bot.client_sessions
+        WHERE name = %(name)s
+        ORDER BY updated_at DESC
+        LIMIT 1
+        """,
+        {"name": name},
+    )
+    rows = result.result_rows
+    return rows[0][0] if rows else None
+
+
+def save_session(name: str, session: str) -> None:
+    """Persist the session string for a given client name."""
+    client = get_clickhouse_client()
+    client.insert(
+        "telegram_user_bot.client_sessions",
+        [[name, session, datetime.utcnow()]],
+        column_names=["name", "session", "updated_at"],
+    )


### PR DESCRIPTION
## Summary
- load existing session strings from ClickHouse when creating Telegram clients
- persist updated session strings back to ClickHouse after successful login
- add migration and utilities for ClickHouse-backed session storage

## Testing
- `python -m py_compile src/main.py`
- `python -m py_compile src/session_storage.py`


------
https://chatgpt.com/codex/tasks/task_e_68a54f201c108325a2ef3ca118ebf66c