### PR TITLE
Handle negative chat IDs for scheduler

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -65,7 +65,12 @@ async def run_telegram_clients():
 
     scheduler = AsyncIOScheduler()
 
-    chat_ids = [int(cid.strip()) for cid in config.chat_ids if cid.strip().isdigit()]
+    chat_ids = []
+    for cid in config.chat_ids:
+        try:
+            chat_ids.append(int(cid.strip()))
+        except ValueError:
+            logging.warning("Invalid chat ID skipped: %s", cid)
     if main_client in started_clients:
         for chat_id in chat_ids:
             scheduler.add_job(


### PR DESCRIPTION
## Summary
- correctly parse chat IDs from config without filtering out negative values
- warn and skip invalid chat IDs

## Testing
- `flake8` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a58387670c8325b964b285d95d293d