### PR TITLE
Use Telethon display name helper

### DIFF
--- a/src/admin_logs.py
+++ b/src/admin_logs.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from difflib import unified_diff
 from typing import Any, List
 
+from telethon import utils
 from telethon.tl.functions.channels import GetAdminLogRequest
 
 from clickhouse_utils import get_clickhouse_client
@@ -77,7 +78,7 @@ def build_event_maps(events):
     title_map = {}
 
     for user in events.users:
-        title_map[user.id] = f"{user.first_name or ''} {user.last_name or ''}".strip()
+        title_map[user.id] = utils.get_display_name(user)
         usernames_map[user.id] = extract_usernames(user)
 
     chat_map = {chat.id: extract_usernames(chat) for chat in events.chats}

--- a/src/main.py
+++ b/src/main.py
@@ -29,10 +29,13 @@ def create_client(session_name: str, api_id: int, api_hash: str) -> TelegramClie
     )
 
 
-
 async def run_telegram_clients():
     main_client = create_client("session/alex", config.api_id, config.api_hash)
-    second_client = create_client("session/alex2", config.api_id_second, config.api_hash_second)
+    second_client = create_client(
+        "session/alex2",
+        config.api_id_second,
+        config.api_hash_second,
+    )
 
     main_client.add_event_handler(save_outgoing, events.NewMessage(outgoing=True))
     main_client.add_event_handler(save_deleted, events.MessageDeleted())

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -5,6 +5,7 @@ import difflib
 from datetime import datetime
 from typing import List
 
+from telethon import utils
 from admin_utils import get_admins
 from username_utils import extract_usernames
 from clickhouse_utils import get_clickhouse_client
@@ -17,26 +18,10 @@ deleted_batch: List[List] = []
 
 async def save_outgoing(event):
     clickhouse = get_clickhouse_client()
-    chat_title = ""
-
-    if hasattr(event.chat, "title"):
-        chat_title = event.chat.title
-    else:
-        if (
-            event.chat is not None
-            and event.chat.bot
-            and hasattr(event.chat, "first_name")
-        ):
-            chat_title = event.chat.first_name
-
     chat = await event.get_chat()
     chat_usernames = extract_usernames(chat)
-
-    if hasattr(chat, "first_name"):
-        last_name = chat.last_name if chat.last_name is not None else ""
-        chat_title = chat.first_name + " " + last_name
-
-    if chat_title == "":
+    chat_title = utils.get_display_name(chat)
+    if not chat_title:
         if chat_usernames:
             chat_title = chat_usernames[0]
         else:


### PR DESCRIPTION
## Summary
- use `utils.get_display_name` from Telethon to derive user titles in admin logs
- rely on Telethon display name for chat titles in outgoing message handler
- fix flake8 complaints in `main.py`

## Testing
- `flake8 && echo 'flake8 passed'`


------
https://chatgpt.com/codex/tasks/task_e_68b79dbd58e48325a586369b48378bb5