### PR TITLE
Limit admin fetching requests

### DIFF
--- a/src/admin_utils.py
+++ b/src/admin_utils.py
@@ -1,3 +1,4 @@
+from telethon.client.chats import _MAX_PARTICIPANTS_CHUNK_SIZE
 from telethon.tl.types import ChatParticipantCreator
 
 from username_utils import extract_usernames
@@ -8,9 +9,10 @@ def build_username(user):
     return f"@{usernames[0]}" if usernames else ""
 
 
-async def get_admins(chat, client, limit=50):
+async def get_admins(chat, client, limit=50, requests_limit=5):
     admins = []
-    async for user in client.iter_participants(chat):
+    max_participants = _MAX_PARTICIPANTS_CHUNK_SIZE * requests_limit
+    async for user in client.iter_participants(chat, limit=max_participants):
         try:
             if user.bot:
                 continue


### PR DESCRIPTION
## Summary
- limit admin fetching to at most five Telegram requests

## Testing
- `python -m flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b82ca44dcc8325bc44bd6369316130