### PR TITLE
Ensure deleted message logging uses last edits

### DIFF
--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -287,14 +287,27 @@ async def save_deleted(event):
             message = clickhouse.query(
                 """
             SELECT message
-            FROM telegram_user_bot.chats_log
-            WHERE chat_id = {chat_id:Int64} and message_id = {message_id:Int64}
+            FROM telegram_user_bot.edited_log
+            WHERE chat_id = {chat_id:Int64} AND message_id = {message_id:Int64}
+            ORDER BY date_time DESC
             LIMIT 1
             """,
                 {"chat_id": event.chat_id, "message_id": msg_id},
             ).result_rows[0][0]
         except Exception:
-            message = msg_id
+            try:
+                message = clickhouse.query(
+                    """
+                SELECT message
+                FROM telegram_user_bot.chats_log
+                WHERE chat_id = {chat_id:Int64} AND message_id = {message_id:Int64}
+                ORDER BY date_time DESC
+                LIMIT 1
+                """,
+                    {"chat_id": event.chat_id, "message_id": msg_id},
+                ).result_rows[0][0]
+            except Exception:
+                message = msg_id
 
         logging.info(
             colorize("deleted", "deleted  %12d %-25s %s"),


### PR DESCRIPTION
## Summary
- look up deleted messages in `edited_log` before falling back to `chats_log`
- keep admin log formatter unchanged

## Testing
- `python -m flake8`
- `python -m py_compile src/admin_logs.py src/scrapper.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0018afaa88325870c70b1813444f7