### PR TITLE
Add numpy dependency for clickhouse client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ clickhouse_connect~=0.9.0
 APScheduler~=3.11.0
 
 clickhouse-migrations~=0.9.1
+numpy>=1.26,<3.0


### PR DESCRIPTION
## Summary
- add numpy to the Python requirements so clickhouse-connect loads successfully

## Testing
- pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68ca3977fad08325a2ba8392ad15be72